### PR TITLE
inverted color opaque fallbacks should get 'darken' instead of 'lighten'

### DIFF
--- a/sass/colors.scss
+++ b/sass/colors.scss
@@ -14,11 +14,11 @@ $C_lineGray: rgba(0,0,0,0.1);
 $C_primaryGrayInverted: rgb(255,255,255);
 @mixin color_primaryGrayInverted { color: $C_primaryGrayInverted; }
 $C_secondaryGrayInverted: rgba(255,255,255,0.67);
-@mixin color_secondaryGrayInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 33%); #{$style}: $C_secondaryGrayInverted; }
+@mixin color_secondaryGrayInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 33%); #{$style}: $C_secondaryGrayInverted; }
 $C_tertiaryGrayInverted: rgba(255,255,255,0.47);
-@mixin color_tertiaryGrayInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 53%); #{$style}: $C_tertiaryGrayInverted; }
+@mixin color_tertiaryGrayInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 53%); #{$style}: $C_tertiaryGrayInverted; }
 $C_lineGrayInverted: rgba(255,255,255,0.2);
-@mixin color_lineGrayInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 80%); #{$style}: $C_lineGrayInverted; }
+@mixin color_lineGrayInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 80%); #{$style}: $C_lineGrayInverted; }
  
 // BACKGROUNDS - these are always 100% opacity
 $C_backgroundContent: rgb(255,255,255);
@@ -62,11 +62,11 @@ $C_buttonTertiaryBorder: rgba(0,0,0,0.47);
 $C_textPrimaryInverted: rgb(255,255,255);
 @mixin color_textPrimaryInverted { color: $C_textPrimaryInverted; }
 $C_textSecondaryInverted: rgba(255,255,255,0.67);
-@mixin color_textSecondaryInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 33%); #{$style}: $C_textSecondaryInverted; }
+@mixin color_textSecondaryInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 33%); #{$style}: $C_textSecondaryInverted; }
 $C_textTertiaryInverted: rgba(255,255,255,0.47);
-@mixin color_textTertiaryInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 53%); #{$style}: $C_textTertiaryInverted; }
+@mixin color_textTertiaryInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 53%); #{$style}: $C_textTertiaryInverted; }
 $C_borderInverted: rgba(255,255,255,0.2);
-@mixin color_borderInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 80%); #{$style}: $C_borderInverted; }
+@mixin color_borderInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 80%); #{$style}: $C_borderInverted; }
 $C_linkInverted: rgb(57,135,203);
 @mixin color_linkInverted { color: $C_linkInverted; }
 $C_accentInverted: rgb(226,55,60);
@@ -74,13 +74,13 @@ $C_accentInverted: rgb(226,55,60);
 $C_yesInverted: rgb(226,55,60);
 @mixin color_yesInverted { color: $C_yesInverted; }
 $C_noInverted: rgba(255,255,255,0.67);
-@mixin color_noInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 33%); #{$style}: $C_noInverted; }
+@mixin color_noInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 33%); #{$style}: $C_noInverted; }
 $C_waitlistInverted: rgba(255,255,255,0.67);
-@mixin color_waitlistInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 33%); #{$style}: $C_waitlistInverted; }
+@mixin color_waitlistInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 33%); #{$style}: $C_waitlistInverted; }
 $C_buttonPrimaryInverted: rgb(226,55,60);
 @mixin color_buttonPrimaryInverted { color: $C_buttonPrimaryInverted; }
 $C_buttonSecondaryInverted: rgba(255,255,255,0.47);
-@mixin color_buttonSecondaryInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 53%); #{$style}: $C_buttonSecondaryInverted; }
+@mixin color_buttonSecondaryInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 53%); #{$style}: $C_buttonSecondaryInverted; }
 $C_buttonTertiaryBorder: rgba(255,255,255,0.47);
 @mixin color_buttonTertiaryBorder($style: 'color') { #{$style}: lighten( rgb(255,255,255), 53%); #{$style}: $C_buttonTertiaryBorder; }
  

--- a/src/build.rb
+++ b/src/build.rb
@@ -24,8 +24,11 @@ color_types.each_value do |color_type|
 			sass_lines << "$C_#{key}: rgb(#{value[0,3].join(',')});"
 			sass_lines << "@mixin color_#{key} { color: $C_#{key}; }"
 		else
+			# if it's an inverted color (dark bg), `darken` the opaque equivalent, else `lighten`
+			color_func = key["Inverted"] ? "darken" : "lighten"
+
 			sass_lines << "$C_#{key}: rgba(#{value.join(',')});"
-			sass_lines << "@mixin color_#{key}($style: 'color') { \#{$style}: lighten( rgb(#{value[0,3].join(',')}), #{((1 - value[3])*100).round}%); \#{$style}: $C_#{key}; }"
+			sass_lines << "@mixin color_#{key}($style: 'color') { \#{$style}: #{color_func}( rgb(#{value[0,3].join(',')}), #{((1 - value[3])*100).round}%); \#{$style}: $C_#{key}; }"
 		end
 	end
 	sass_lines << " "


### PR DESCRIPTION
e.g.

``` scss
// wrong (current):
$C_lineGrayInverted: rgba(255,255,255,0.2);
@mixin color_lineGrayInverted($style: 'color') { #{$style}: lighten( rgb(255,255,255), 80%); #{$style}: $C_lineGrayInverted; }

// better
$C_lineGrayInverted: rgba(255,255,255,0.2);
@mixin color_lineGrayInverted($style: 'color') { #{$style}: darken( rgb(255,255,255), 80%); #{$style}: $C_lineGrayInverted; }
```
