### PR TITLE
add tools:ignore bit to android output

### DIFF
--- a/android/colors.xml
+++ b/android/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated code: DO NOT EDIT -->
-<!-- Last update: June 02, 2016 -->
-<resources>
+<!-- Last update: July 05, 2016 -->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
 
   <!-- Base color palette -->
   <color name="foundation_white">#ffffffff</color>

--- a/src/build.rb
+++ b/src/build.rb
@@ -50,7 +50,8 @@ File.open("../android/colors.xml", 'w+') do |file|
 	xml.instruct!
 	xml.comment! "Generated code: DO NOT EDIT"
 	xml.comment! "Last update: #{Time.now.strftime('%B %d, %Y')}"
-	xml.resources do
+	xml.resources "xmlns:tools" => "http://schemas.android.com/tools",
+	              "tools:ignore" => "UnusedResources" do
 		mapping.children.each_slice(2) do |ignore, color_type|
 			xml << "\n"
 			xml.comment! color_type.children[1].value


### PR DESCRIPTION
this adds an attribute to the android `colors.xml` output which instructs the [android lint](https://developer.android.com/studio/write/lint.html) tool not to complain about colors which are present here but not (yet/ever) used by the android app.